### PR TITLE
Implemented manual_overrides functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,52 +9,41 @@ Authors
 -------
 
 * Daniel L. Parton | daniel.parton@choderalab.org
+* Mehtap Isik | mehtap.isik@choderalab.org
 * John D. Chodera | john.chodera@choderalab.org
 
 Overview
 --------
 
-Database framework for storing genomic, structural and functional data for a
-given protein family, with RESTful API.
-
-The code is built on [Flask](http://flask.pocoo.org/) (a Python web framework)
-and [SQLAlchemy](http://www.sqlalchemy.org/) (an object-relational mapper which
-maps between SQL databases and Python objects).
+The code is built using the [Flask](http://flask.pocoo.org/) a Python web framework
+and [SQLAlchemy](http://www.sqlalchemy.org/) - an object-relational mapper which
+maps between Python objects and SQL databases.
 
 The database is generated using a series of scripts which gather in data from
 various public web resources. The first script to run is DoraInit.py, which
 initializes the necessary files and directory structure for a new database.
 This should be followed by DoraGatherUniProt.py, which retrieves a set of
 [UniProt](http://www.uniprot.org/) entries defined by a given search term.
-Subsequent scripts (once they have been migrated over from the old _XML_
-branch) add in data from various other databases such as the
+Subsequent scripts add in data from various other databases such as the
 [PDB](http://www.rcsb.org), [NCBI Gene](http://www.ncbi.nlm.nih.gov/gene),
 [cBioPortal](http://www.cbioportal.org), and
 [BindingDB](http://www.bindingdb.org/bind/index.jsp). Finally, DoraCommit.py is
-used to carry out a sanity check on the new data; if this passes, the new data
-will be exposed through the API.
+used to ensure that all gather scripts have been run since the last commit;
+if this passes, the new data is *committed*, meaning it can then be exposed through the API.
 
 A [frontend web client](https://github.com/choderalab/kinomeDB-webclient) is
-currently in development, and an early working version can be seen here:
+currently in development.
 
-http://plfah2.mskcc.org/kinomeDB/
+Installation using Anaconda (recommended approach)
+--------------------------------------------------
 
-Manifest
---------
+First install [Anaconda](https://store.continuum.io/cshop/anaconda/) - a free and awesome Python
+distribution for scientific and data-intensive applications.
 
-scripts/ - scripts for generating and analyzing the database
-
-TargetExplorer/ - main code library
-
-flask\_app/ - data model and Flask HTTP server (master)
-
-resources/ - other miscellaneous files
-
-Dependencies
-------------
-
-* BioPython, v1.62 or higher
-* Various other Python packages commonly used in scientific computing. Recommended aproach is to install either Continuum Anaconda (https://store.continuum.io/) or Enthought Canopy (https://www.enthought.com/products/canopy/)
+```.sh
+conda config --add channels http://anaconda.org/choderalab
+conda install targetexplorer
+```
 
 Notes on database generation process
 ------------------------------------

--- a/scripts/DoraGatherUniProt.py
+++ b/scripts/DoraGatherUniProt.py
@@ -22,7 +22,6 @@ GatherUniProt(
     count_nonselected_domain_names=args.count_nonselected_domain_names,
     uniprot_query=project_config['uniprot_query'],
     uniprot_domain_regex=project_config['uniprot_domain_regex'],
-    ignore_uniprot_pdbs=project_config['ignore_uniprot_pdbs'],
 )
 
 print('Done.')

--- a/targetexplorer/cbioportal.py
+++ b/targetexplorer/cbioportal.py
@@ -229,8 +229,8 @@ class GatherCbioportalData(object):
 
     def finish(self):
         # update db datestamps
-        current_crawl_datestamp_row = models.DateStamps.query.filter_by(crawl_number=self.current_crawl_number).first()
-        current_crawl_datestamp_row.cbioportal_datestamp = self.now
+        datestamp_row = models.DateStamps.query.filter_by(crawl_number=self.current_crawl_number).first()
+        datestamp_row.cbioportal_datestamp = self.now
         db.session.commit()
         print 'Done.'
 

--- a/targetexplorer/core.py
+++ b/targetexplorer/core.py
@@ -12,6 +12,7 @@ import logging
 datestamp_format_string = '%Y-%m-%d %H:%M:%S UTC'
 
 project_config_filename = 'project_config.yaml'
+manual_overrides_filename = 'manual_overrides.yaml'
 database_filename = 'database.db'
 wsgi_filename = 'webapi-wsgi.py'
 external_data_dirpath = 'external-data'
@@ -31,6 +32,23 @@ def read_project_config():
     if os.path.exists(project_config_filename):
         with open(project_config_filename) as config_file:
             config = yaml.load(config_file)
+        return config
+    else:
+        return dict()
+
+
+def read_manual_overrides():
+    """
+    Tries to import a manual overrides file and return the data as a dict.
+    If no config file is found, then an empty dict is returned.
+
+    Returns
+    -------
+    dict
+    """
+    if os.path.exists(manual_overrides_filename):
+        with open(manual_overrides_filename) as manual_overrides_file:
+            config = yaml.load(manual_overrides_file)
         return config
     else:
         return dict()

--- a/targetexplorer/flaskapp/models.py
+++ b/targetexplorer/flaskapp/models.py
@@ -17,7 +17,7 @@ frontend2backend_mappings = {
     'species': ['UniProt', 'taxon_name_common'],
     'domain_length': ['UniProtDomain', 'length'],
     'subcellular_location': ['UniProtSubcellularLocation', 'subcellular_location'],
-    # TODO 'pseudodomain': ['UniProtDomain', 'pseudodomain'],
+    'pseudodomain': ['UniProtDomain', 'is_pseudodomain'],
 }
 
 
@@ -29,6 +29,7 @@ class CrawlData(db.Model):
     safe_crawl_datestamp = db.Column(db.DateTime)
     def __repr__(self):
         return '<DB CrawlData current crawl number %d safe crawl number %d>' % (self.current_crawl_number, self.safe_crawl_number)
+
 
 class DateStamps(db.Model):
     __tablename__ = 'datestamps'
@@ -42,6 +43,7 @@ class DateStamps(db.Model):
     commit_datestamp = db.Column(db.DateTime)
     def __repr__(self):
         return '<DB DateStamps crawl number %d>' % self.crawl_number
+
 
 class DBEntry(db.Model):
     __tablename__ = 'dbentry'
@@ -70,6 +72,7 @@ class DBEntry(db.Model):
     def __repr__(self):
         return '<DBEntry %d>' % self.id
 
+
 class UniProt(db.Model):
     __tablename__ = 'uniprot'
     id = db.Column(db.Integer, primary_key=True)
@@ -93,6 +96,7 @@ class UniProt(db.Model):
     def __repr__(self):
         return '<UniProt AC %r entry_name %r>' % (self.ac, self.entry_name)
 
+
 class UniProtGeneName(db.Model):
     __tablename__ = 'uniprotgenename'
     id = db.Column(db.Integer, primary_key=True)
@@ -104,12 +108,13 @@ class UniProtGeneName(db.Model):
     def __repr__(self):
         return '<UniProtGeneName %r>' % self.gene_name
 
+
 class UniProtIsoform(db.Model):
     __tablename__ = 'uniprotisoform'
     id = db.Column(db.Integer, primary_key=True)
     crawl_number = db.Column(db.Integer)
     ac = db.Column(db.String(64))
-    canonical = db.Column(db.Boolean)
+    is_canonical = db.Column(db.Boolean)
     length = db.Column(db.Integer)
     mass = db.Column(db.Integer)
     date_modified = db.Column(db.String(64))
@@ -120,7 +125,8 @@ class UniProtIsoform(db.Model):
     dbentry_id = db.Column(db.Integer, db.ForeignKey('dbentry.id'))
     uniprot_id = db.Column(db.Integer, db.ForeignKey('uniprot.id'))
     def __repr__(self):
-        return '<UniProtIsoform %r canonical: %r>' % (self.ac, self.canonical)
+        return '<UniProtIsoform %r canonical: %r>' % (self.ac, self.is_canonical)
+
 
 class UniProtIsoformNote(db.Model):
     __tablename__ = 'uniprotisoformnote'
@@ -131,22 +137,26 @@ class UniProtIsoformNote(db.Model):
     def __repr__(self):
         return '<UniProtIsoformNote %r>' % self.note
 
+
 class UniProtDomain(db.Model):
     __tablename__ = 'uniprotdomain'
     id = db.Column(db.Integer, primary_key=True)
     crawl_number = db.Column(db.Integer)
+    is_target_domain = db.Column(db.Boolean)
     targetid = db.Column(db.String(64))
     description = db.Column(db.Text())
     begin = db.Column(db.Integer)
     end = db.Column(db.Integer)
     length = db.Column(db.Integer)
     sequence = db.Column(db.Text)
-    # pseudodomain = db.Column(db.Boolean)
+    is_pseudodomain = db.Column(db.Boolean)
+    pseudodomain_notes = db.Column(db.Text)
     cbioportal_mutations = db.relationship('CbioportalMutation', backref='uniprot_domain', lazy='dynamic')
     dbentry_id = db.Column(db.Integer, db.ForeignKey('dbentry.id'))
     uniprot_id = db.Column(db.Integer, db.ForeignKey('uniprot.id'))
     def __repr__(self):
-        return '<UniProtDomain targetid %r>' % self.targetid
+        return '<UniProtDomain description %r>' % self.description
+
 
 class UniProtFunction(db.Model):
     __tablename__ = 'uniprotfunction'
@@ -158,6 +168,7 @@ class UniProtFunction(db.Model):
     def __repr__(self):
         return '<UniProtFunction %r>' % self.function
 
+
 class UniProtDiseaseAssociation(db.Model):
     __tablename__ = 'uniprotdiseaseassociation'
     id = db.Column(db.Integer, primary_key=True)
@@ -168,6 +179,7 @@ class UniProtDiseaseAssociation(db.Model):
     def __repr__(self):
         return '<UniProtDiseaseAssociation %r>' % self.disease_association
 
+
 class UniProtSubcellularLocation(db.Model):
     __tablename__ = 'uniprotsubcellularlocation'
     id = db.Column(db.Integer, primary_key=True)
@@ -177,6 +189,7 @@ class UniProtSubcellularLocation(db.Model):
     uniprot_id = db.Column(db.Integer, db.ForeignKey('uniprot.id'))
     def __repr__(self):
         return '<UniProtSubcellularLocation %r>' % self.subcellular_location
+
 
 class PDB(db.Model):
     __tablename__ = 'pdb'
@@ -190,6 +203,7 @@ class PDB(db.Model):
     dbentry_id = db.Column(db.Integer, db.ForeignKey('dbentry.id'))
     def __repr__(self):
         return '<PDB ID %r>' % self.pdbid
+
 
 class PDBChain(db.Model):
     __tablename__ = 'pdbchain'
@@ -209,6 +223,7 @@ class PDBChain(db.Model):
     def __repr__(self):
         return '<PDBChain ID %r>' % self.chain_id
 
+
 class PDBExpressionData(db.Model):
     __tablename__ = 'pdbexpressiondata'
     id = db.Column(db.Integer, primary_key=True)
@@ -218,6 +233,7 @@ class PDBExpressionData(db.Model):
     pdb_id = db.Column(db.Integer, db.ForeignKey('pdb.id'))
     def __repr__(self):
         return '<PDBExpressionData id %r>' % self.id
+
 
 class NCBIGeneEntry(db.Model):
     __tablename__ = 'ncbi_gene_entry'
@@ -229,6 +245,7 @@ class NCBIGeneEntry(db.Model):
     def __repr__(self):
         return '<NCBIGeneEntry ID %r>' % self.gene_id
 
+
 class NCBIGenePublication(db.Model):
     __tablename__ = 'ncbi_gene_publication'
     id = db.Column(db.Integer, primary_key=True)
@@ -237,6 +254,7 @@ class NCBIGenePublication(db.Model):
     ncbi_gene_entry_id = db.Column(db.Integer, db.ForeignKey('ncbi_gene_entry.id'))
     def __repr__(self):
         return '<NCBIGenePublication PMID %r>' % self.pmid
+
 
 class EnsemblGene(db.Model):
     __tablename__ = 'ensembl_gene'
@@ -249,6 +267,7 @@ class EnsemblGene(db.Model):
     def __repr__(self):
         return '<EnsemblGene ID %r>' % self.gene_id
 
+
 class EnsemblTranscript(db.Model):
     __tablename__ = 'ensembl_transcript'
     id = db.Column(db.Integer, primary_key=True)
@@ -260,6 +279,7 @@ class EnsemblTranscript(db.Model):
     def __repr__(self):
         return '<EnsemblTranscript ID %r>' % self.transcript_id
 
+
 class EnsemblProtein(db.Model):
     __tablename__ = 'ensembl_protein'
     id = db.Column(db.Integer, primary_key=True)
@@ -270,6 +290,7 @@ class EnsemblProtein(db.Model):
     def __repr__(self):
         return '<EnsemblProtein ID %r>' % self.protein_id
 
+
 class HGNCEntry(db.Model):
     __tablename__ = 'hgnc_entry'
     id = db.Column(db.Integer, primary_key=True)
@@ -279,6 +300,7 @@ class HGNCEntry(db.Model):
     dbentry_id = db.Column(db.Integer, db.ForeignKey('dbentry.id'))
     def __repr__(self):
         return '<HGNCEntry approved_symbol %r>' % self.approved_symbol
+
 
 class BindingDBBioassay(db.Model):
     __tablename__ = 'bindingdb_bioassay'
@@ -307,6 +329,7 @@ class BindingDBBioassay(db.Model):
     def __repr__(self):
         return '<BindingDB bioassay>'
 
+
 # class BindingDBMeasurement(db.Model):
 #     __tablename__ = 'bindingdb_measurement'
 #     id = db.Column(db.Integer, primary_key=True)
@@ -317,6 +340,7 @@ class BindingDBBioassay(db.Model):
 #     def __repr__(self):
 #         return '<BindingDB measurement type: %r value: %r>' % (self.measurement_type, self.measurement_value)
 
+
 class CbioportalCase(db.Model):
     __tablename__ = 'cbioportal_case'
     id = db.Column(db.Integer, primary_key=True)
@@ -326,6 +350,7 @@ class CbioportalCase(db.Model):
     mutations = db.relationship('CbioportalMutation', backref='cbioportal_case', lazy='dynamic')
     def __repr__(self):
         return '<CbioportalCase ID {0}>'.format(self.case_id)
+
 
 class CbioportalMutation(db.Model):
     __tablename__ = 'cbioportal_mutation'

--- a/targetexplorer/pdb.py
+++ b/targetexplorer/pdb.py
@@ -52,7 +52,7 @@ class GatherPDB(object):
         for pdb_row in db_pdb_rows:
             dbentry = models.DBEntry.query.filter_by(id=pdb_row.dbentry_id).first()
             uniprot_row = dbentry.uniprot.first()
-            canon_isoform_row = dbentry.uniprotisoforms.filter_by(canonical=True).first()
+            canon_isoform_row = dbentry.uniprotisoforms.filter_by(is_canonical=True).first()
             chain_data = [
                 {
                     'chain_row_id': chain_row.id,

--- a/targetexplorer/tests/test_cbioportal.py
+++ b/targetexplorer/tests/test_cbioportal.py
@@ -1,8 +1,9 @@
 from targetexplorer.flaskapp import models
 from targetexplorer.tests.utils import projecttest_context
-from targetexplorer.cbioportal import GatherCbioportalData
+from targetexplorer.cbioportal import GatherCbioportalData, retrieve_extended_mutation_datatxt
 from targetexplorer.oncotator import retrieve_oncotator_mutation_data_as_json
 from nose.plugins.attrib import attr
+from nose.plugins.skip import SkipTest
 
 
 @attr('network')
@@ -15,6 +16,32 @@ def test_retrieve_oncotator_mutation_data_as_json():
         'G'
     )
     assert oncotator_result.get('transcript_id') == 'ENST00000275493.2'
+
+
+@attr('network')
+def test_retrieve_extended_mutation_datatxt():
+    lines = retrieve_extended_mutation_datatxt(
+        'gbm_tcga_all',
+        'gbm_tcga_mutations',
+        ['EGFR', 'PTEN']
+    )
+    assert len(lines) > 0
+
+
+@attr('private_cbioportal')
+def test_retrieve_extended_mutation_datatxt_private_portal():
+    """
+    So far seems to be impossible to access private data via web API.
+    """
+    raise SkipTest
+    lines = retrieve_extended_mutation_datatxt(
+        'gbm_tcga_all',
+        'gbm_tcga_mutations',
+        ['EGFR', 'PTEN'],
+        portal_version='private'
+    )
+    print '\n'.join(lines)
+    assert len(lines) > 0
 
 
 @attr('unit')


### PR DESCRIPTION
Allows a user to include a yaml file to specify manual overrides such as:
* skip certain UniProt entries, PDB entries etc.
* manually annotate certain data types, e.g. to annotate a domain as a pseudodomain