### PR TITLE
Converting function in cBio portal to loop over gene ids and avoid long url 

### DIFF
--- a/targetexplorer/cbioportal.py
+++ b/targetexplorer/cbioportal.py
@@ -14,7 +14,6 @@ from targetexplorer.utils import json_dump_pretty, set_loglevel
 from targetexplorer.oncotator import retrieve_oncotator_mutation_data_as_json, build_oncotator_search_string
 from targetexplorer.flaskapp import models, db
 
-
 external_data_dir = os.path.join(external_data_dirpath, 'cBioPortal')
 external_cbioportal_data_filepath = os.path.join(external_data_dir, 'cbioportal-mutations.xml')
 external_oncotator_data_filepath = os.path.join(external_data_dir, 'oncotator-data.json.gz')
@@ -63,13 +62,13 @@ class GatherCbioportalData(object):
             in models.UniProtEntry.query.filter_by(
                 crawl_number=self.current_crawl_number
             ).values(models.UniProtEntry.ac)
-        ]
+            ]
         self.hgnc_gene_symbols = [
             value_tuple[0] for value_tuple
             in models.HGNCEntry.query.filter_by(
                 crawl_number=self.current_crawl_number
             ).values(models.HGNCEntry.approved_symbol)
-        ]
+            ]
 
     def get_mutation_data_as_xml(self):
         if os.path.exists(external_cbioportal_data_filepath) and self.use_existing_cbioportal_data:
@@ -133,7 +132,8 @@ class GatherCbioportalData(object):
                     in_uniprot_domain=False,
                 )
 
-                if mutation_type == 'Missense_Mutation' and None not in [chromosome_index, chromosome_startpos, chromosome_endpos]:
+                if mutation_type == 'Missense_Mutation' and None not in [chromosome_index, chromosome_startpos,
+                                                                         chromosome_endpos]:
                     oncotator_data = self.get_oncotator_data(
                         chromosome_index,
                         chromosome_startpos,
@@ -177,7 +177,7 @@ class GatherCbioportalData(object):
             chromosome_endpos,
             reference_allele,
             variant_allele
-            ):
+    ):
         oncotator_search_string = build_oncotator_search_string(
             chromosome_index,
             chromosome_startpos,
@@ -187,10 +187,10 @@ class GatherCbioportalData(object):
         )
 
         if (
-                self.use_existing_oncotator_data and self.existing_oncotator_data
+                        self.use_existing_oncotator_data and self.existing_oncotator_data
                 and oncotator_search_string in self.existing_oncotator_data
-                ):
-                oncotator_data = self.existing_oncotator_data[oncotator_search_string]
+        ):
+            oncotator_data = self.existing_oncotator_data[oncotator_search_string]
         else:
             oncotator_data = retrieve_oncotator_mutation_data_as_json(
                 chromosome_index,
@@ -265,7 +265,8 @@ def get_genetic_profile_ids(cancer_study):
     """
     For a given cancer study, return a list of available genetic_profile_ids (e.g. 'laml_tcga_pub_mutations')
     """
-    genetic_profile_url = 'http://www.cbioportal.org/public-portal/webservice.do?cmd=getGeneticProfiles&cancer_study_id={0}'.format(cancer_study)
+    genetic_profile_url = 'http://www.cbioportal.org/public-portal/webservice.do?cmd=getGeneticProfiles&cancer_study_id={0}'.format(
+        cancer_study)
     response = urllib2.urlopen(genetic_profile_url)
     page = response.read(100000000000)
     lines = page.splitlines()
@@ -294,7 +295,7 @@ def get_profile_data(case_set_id, genetic_profile_id, entrez_gene_ids):
     """
     # TODO probably deprecate this once get_mutations and get_CNAs are ready
 
-    gene_list_string = '+'.join( [ str(gene_id) for gene_id in entrez_gene_ids ] )
+    gene_list_string = '+'.join([str(gene_id) for gene_id in entrez_gene_ids])
     mutation_url = 'http://www.cbioportal.org/public-portal/webservice.do?cmd=getProfileData&case_set_id=%(case_set_id)s&genetic_profile_id=%(genetic_profile_id)s&gene_list=%(gene_list_string)s' % vars()
     response = urllib2.urlopen(mutation_url)
     page = response.read(100000000000)
@@ -348,7 +349,7 @@ def retrieve_mutants_xml(output_xml_filepath, cancer_studies, gene_ids,
         print 'Retrieving ExtendedMutation data from cBioPortal for study %s...' % cancer_study
 
         if write_extended_mutation_txt_files:
-            txt_output_filepath = os.path.join(external_data_dir, cancer_study+'.txt')
+            txt_output_filepath = os.path.join(external_data_dir, cancer_study + '.txt')
         else:
             txt_output_filepath = False
 
@@ -363,7 +364,7 @@ def retrieve_mutants_xml(output_xml_filepath, cancer_studies, gene_ids,
             continue
         if lines[0][0:25] == '# Warning:  Unknown gene:':
             print lines[0]
-            #raise Exception
+            # raise Exception
             continue
         print 'Done retrieving ExtendedMutation data from cBioPortal.'
 
@@ -378,64 +379,71 @@ def retrieve_mutants_xml(output_xml_filepath, cancer_studies, gene_ids,
         # 1956  EGFR    TCGA-16-1048    broad.mit.edu   Somatic Missense_Mutation   NA  F254I   M   [getma.org/...snip]   [getma.org/...snip] [getma.org/...snip] 7   55221716    55221716    T   A   gbm_tcga_mutations
         # EXCEPT for dual mutations of consecutive aas, e.g.:
         # 51231 VRK3    TCGA-AA-A01V    broad.mit.edu   Somatic Missense_Mutation   Unknown 324_325LA>FS    NA  NA  NA  NA  19  50493019    50493020    CC  AA  coadread_tcga_pub_mutations
-        for line in lines[2:]:
-            words = line.split('\t')
-            returned_gene_id = words[1]
-            case_id = words[2]
-            mutation_status = words[4] # 'Somatic', ?'Germline'
-            mutation_type = words[5] # 'Missense_Mutation', ...
-            validation_status = words[6] # 'NA', ???
-            aa_changes = [ words[7] ] # 'F254I', '324_325LA>FS'
-            functional_impact_score = words[8]
-            chromosome_index = words[12]
-            chromosome_startpos = words[13]
-            chromosome_endpos = words[14]
-            reference_allele = words[15]
-            variant_allele = words[16]
-            #returned_cancer_study = words[-1][ 0 : words[-1].rfind('_mutations') ]
+        for line in lines:
+            try:
+                words = line.split('\t')
+                returned_gene_id = words[1]
+                case_id = words[2]
+                mutation_status = words[4]  # 'Somatic', ?'Germline'
+                mutation_type = words[5]  # 'Missense_Mutation', ...
+                validation_status = words[6]  # 'NA', ???
+                aa_changes = [words[7]]  # 'F254I', '324_325LA>FS'
+                functional_impact_score = words[8]
+                chromosome_index = words[12]
+                chromosome_startpos = words[13]
+                chromosome_endpos = words[14]
+                reference_allele = words[15]
+                variant_allele = words[16]
+                # returned_cancer_study = words[-1][ 0 : words[-1].rfind('_mutations') ]
 
-            # _______________
-            # Some exceptions
-            # ---------------
+                # _______________
+                # Some exceptions
+                # ---------------
 
-            if aa_changes[0] == 'MUTATED':
-                aa_changes[0] = 'Unknown'
+                if aa_changes[0] == 'MUTATED':
+                    aa_changes[0] = 'Unknown'
 
-            # Dual mutations of consecutive aas
-            if mutation_type == 'Missense_Mutation' and match_dual_consecutive_aa_change(aa_changes[0]):
-                aa_changes = split_dual_consecutive_aa_change(aa_changes[0])
+                # Dual mutations of consecutive aas
+                if mutation_type == 'Missense_Mutation' and match_dual_consecutive_aa_change(aa_changes[0]):
+                    aa_changes = split_dual_consecutive_aa_change(aa_changes[0])
 
-            if returned_gene_id == 'C9ORF96':
-                returned_gene_id = 'C9orf96'
+                if returned_gene_id == 'C9ORF96':
+                    returned_gene_id = 'C9orf96'
 
-            # _______________
+                # _______________
 
-            for aa_change in aa_changes:
-                # Look for a mutant node (corresponding to this study and case_id). This will only exist if a mutation has already been added for this mutant.
-                case_node = gene_nodes_dict[returned_gene_id].find('case[@study="%s"][@case_id="%s"]' % (cancer_study, case_id))
-                # If not found, create it.
-                if case_node == None:
-                    case_node = etree.SubElement(gene_nodes_dict[returned_gene_id], 'case')
-                    case_node.set('source', 'cBioPortal')
-                    case_node.set('study', cancer_study)
-                    case_node.set('case_id', case_id)
-                    mutant_nodes_by_case_id[case_id] = case_node
+                for aa_change in aa_changes:
+                    # Look for a mutant node (corresponding to this study and case_id). This will only exist if a mutation has already been added for this mutant.
+                    case_node = gene_nodes_dict[returned_gene_id].find(
+                        'case[@study="%s"][@case_id="%s"]' % (cancer_study, case_id))
+                    # If not found, create it.
+                    if case_node == None:
+                        case_node = etree.SubElement(gene_nodes_dict[returned_gene_id], 'case')
+                        case_node.set('source', 'cBioPortal')
+                        case_node.set('study', cancer_study)
+                        case_node.set('case_id', case_id)
+                        mutant_nodes_by_case_id[case_id] = case_node
 
-                # Each mutation gets a mutation_mode
-                mutation_node = etree.SubElement(case_node, 'mutation')
-                mutation_node.set('mutation_origin', mutation_status)
-                mutation_node.set('mutation_type', mutation_type)
-                mutation_node.set('validation_status', validation_status)
-                mutation_node.set('aa_change', aa_change)
-                mutation_node.set('functional_impact_score', functional_impact_score)
-                mutation_node.set('chromosome_index', chromosome_index)
-                mutation_node.set('chromosome_startpos', chromosome_startpos)
-                mutation_node.set('chromosome_endpos', chromosome_endpos)
-                mutation_node.set('reference_allele', reference_allele)
-                mutation_node.set('variant_allele', variant_allele)
+                    # Each mutation gets a mutation_mode
+                    mutation_node = etree.SubElement(case_node, 'mutation')
+                    mutation_node.set('mutation_origin', mutation_status)
+                    mutation_node.set('mutation_type', mutation_type)
+                    mutation_node.set('validation_status', validation_status)
+                    mutation_node.set('aa_change', aa_change)
+                    mutation_node.set('functional_impact_score', functional_impact_score)
+                    mutation_node.set('chromosome_index', chromosome_index)
+                    mutation_node.set('chromosome_startpos', chromosome_startpos)
+                    mutation_node.set('chromosome_endpos', chromosome_endpos)
+                    mutation_node.set('reference_allele', reference_allele)
+                    mutation_node.set('variant_allele', variant_allele)
 
-                # This dict is used later to assign percent_in_cohort values to mutations by matching case_id and aa_change
-                mutation_nodes_by_case_id_and_aa_change[case_id + aa_change] = mutation_node
+                    # This dict is used later to assign percent_in_cohort values to mutations by matching case_id and aa_change
+                    mutation_nodes_by_case_id_and_aa_change[case_id + aa_change] = mutation_node
+
+            except IndexError:
+                print('Got an IndexError with the following line: {0}...skipping it'.format(line))
+                continue
+
 
         # ============
 
@@ -469,31 +477,36 @@ def retrieve_mutants_xml(output_xml_filepath, cancer_studies, gene_ids,
             # Also require a list of case_ids for each individual aa_change
             case_ids_returned_by_aa_change = []
             for a, aa_change_string in enumerate(aa_change_strings):
-                aa_changes_split_comma = aa_change_string.split(',') # May result in ['R23K', '56_57EG>AH']
+                aa_changes_split_comma = aa_change_string.split(',')  # May result in ['R23K', '56_57EG>AH']
                 aa_changes = []
                 for b in range(len(aa_changes_split_comma)):
                     if match_dual_consecutive_aa_change(aa_changes_split_comma[b]):
                         aa_changes += split_dual_consecutive_aa_change(aa_changes_split_comma[b])
                     else:
-                        aa_changes.append( aa_changes_split_comma[b] )
+                        aa_changes.append(aa_changes_split_comma[b])
 
                 all_aa_changes_this_cohort += aa_changes
-                case_ids_returned_by_aa_change += ( [case_ids_returned[a]] * len(aa_changes) )
+                case_ids_returned_by_aa_change += ([case_ids_returned[a]] * len(aa_changes))
 
             # Number of aas with any aa_change for this gene and cancer study
-            num_in_cohort_any_aa_change = sum( [ 1 for x in aa_change_strings if x != 'NaN' ] )
+            num_in_cohort_any_aa_change = sum([1 for x in aa_change_strings if x != 'NaN'])
             percent_in_cohort_any_aa_change = float(num_in_cohort_any_aa_change) / num_in_cohort * 100.
 
             for a, aa_change in enumerate(all_aa_changes_this_cohort):
                 if aa_change not in ['NaN', 'MUTATED']:
-                    num_in_cohort_this_aa_change = sum( [ 1 for x in all_aa_changes_this_cohort if x == aa_change ] )
+                    num_in_cohort_this_aa_change = sum([1 for x in all_aa_changes_this_cohort if x == aa_change])
                     # Calculate percent_in_cohort
                     percent_in_cohort_this_aa_change = float(num_in_cohort_this_aa_change) / num_in_cohort * 100.
-                    mutation_nodes_by_case_id_and_aa_change[ case_ids_returned_by_aa_change[a] + aa_change ].set('percent_in_cohort_this_aa_change', '%.3f' % percent_in_cohort_this_aa_change)
-                    mutation_nodes_by_case_id_and_aa_change[ case_ids_returned_by_aa_change[a] + aa_change ].getparent().set('percent_in_cohort_any_aa_change', '%.3f' % percent_in_cohort_any_aa_change)
-                    mutation_nodes_by_case_id_and_aa_change[ case_ids_returned_by_aa_change[a] + aa_change ].getparent().set('num_in_cohort', str(num_in_cohort))
+                    mutation_nodes_by_case_id_and_aa_change[case_ids_returned_by_aa_change[a] + aa_change].set(
+                        'percent_in_cohort_this_aa_change', '%.3f' % percent_in_cohort_this_aa_change)
+                    mutation_nodes_by_case_id_and_aa_change[
+                        case_ids_returned_by_aa_change[a] + aa_change].getparent().set(
+                        'percent_in_cohort_any_aa_change', '%.3f' % percent_in_cohort_any_aa_change)
+                    mutation_nodes_by_case_id_and_aa_change[
+                        case_ids_returned_by_aa_change[a] + aa_change].getparent().set('num_in_cohort',
+                                                                                       str(num_in_cohort))
 
-        # ============
+                    # ============
 
     # ===========
     # Write XML to file
@@ -502,7 +515,7 @@ def retrieve_mutants_xml(output_xml_filepath, cancer_studies, gene_ids,
     with open(output_xml_filepath, 'w') as output_xml_file:
         output_xml_file.write(etree.tostring(results_node, pretty_print=True))
 
-    # ===========
+        # ===========
 
 
 def retrieve_mutation_datatxt(case_set_id,
@@ -522,11 +535,11 @@ def retrieve_mutation_datatxt(case_set_id,
                    '&case_set_id={1}' \
                    '&genetic_profile_id={2}' \
                    '&gene_list={3}'.format(
-                       portal_version,
-                       case_set_id,
-                       genetic_profile_id,
-                       gene_ids_string
-                   )
+        portal_version,
+        case_set_id,
+        genetic_profile_id,
+        gene_ids_string
+    )
     if verbose:
         set_loglevel('debug')
         logger.debug(mutation_url)
@@ -537,7 +550,6 @@ def retrieve_mutation_datatxt(case_set_id,
 
 
 def chunk_generator(list_name, n_per_chunk):
-
     """
 
     :param list_name: name of list to chunk over
@@ -566,9 +578,10 @@ def retrieve_extended_mutation_datatxt(case_set_id,
     write_to_filepath: str (or False)
     """
     lines_list = []
-
+    string_to_remove_1 = "# DATA_TYPE\t Mutations"
+    string_to_remove_2 = 'entrez_gene_id\tgene_symbol\tcase_id\tsequencing_center\tmutation_status\tmutation_type\tvalidation_status\tamino_acid_change\tfunctional_impact_score\txvar_link\txvar_link_pdb\txvar_link_msa\tchr\tstart_position\tend_position\treference_allele\tvariant_allele\treference_read_count_tumor\tvariant_read_count_tumor\treference_read_count_normal\tvariant_read_count_normal\tgenetic_profile_id'
     chunks = chunk_generator(gene_ids, 100)
-    for i, chunk in enumerate(chunks):
+    for chunk in chunks:
         gene_ids_string = '+'.join(chunk)
         mutation_url = 'http://www.cbioportal.org/{0}/' \
                        'webservice.do' \
@@ -576,23 +589,29 @@ def retrieve_extended_mutation_datatxt(case_set_id,
                        '&case_set_id={1}' \
                        '&genetic_profile_id={2}' \
                        '&gene_list={3}'.format(
-                           portal_version,
-                           case_set_id,
-                           genetic_profile_id,
-                           gene_ids_string
-                       )
+            portal_version,
+            case_set_id,
+            genetic_profile_id,
+            gene_ids_string
+        )
         response = urllib2.urlopen(mutation_url)
         page = response.read(1000000000)
         if write_to_filepath:
             with open(write_to_filepath, 'w') as ofile:
                 ofile.write(page)
         lines = page.splitlines()
-        if i == 0:
-            lines_list.extend(lines)
-        else:
-            lines_list.extend(lines[2:])
+        while string_to_remove_1 in lines:
+            try:
+                lines.remove(string_to_remove_1)
+            except ValueError:
+                print('{0} not in list'.format(string_to_remove_1))
+        while string_to_remove_2 in lines:
+            try:
+                lines.remove(string_to_remove_2)
+            except ValueError:
+                print('{0} not in list'.format(string_to_remove_2))
+        lines_list.extend(lines)
         time.sleep(random.uniform(0, 0.1))
-    print(lines_list)
     return lines_list
 
 
@@ -603,13 +622,13 @@ def match_dual_consecutive_aa_change(aa_change_string):
     Checks the aas are consecutive.
     """
     # searches for the 'LA>FS' type pattern - putting the regex in parentheses means that the matched pattern will also be returned in the list
-    match = re.match('^[0-9]+_[0-9]+[A-Z][A-Z]>[A-Z][A-Z]', aa_change_string) # ['324_325', 'LA>FS', '']
+    match = re.match('^[0-9]+_[0-9]+[A-Z][A-Z]>[A-Z][A-Z]', aa_change_string)  # ['324_325', 'LA>FS', '']
 
     if not match:
         return False
 
-    aa_change_string_split = re.split('([A-Z][A-Z]>[A-Z][A-Z])', aa_change_string) # ['324_325', 'LA>FS', '']
-    positions = aa_change_string_split[0].split('_') # ['324', '325']
+    aa_change_string_split = re.split('([A-Z][A-Z]>[A-Z][A-Z])', aa_change_string)  # ['324_325', 'LA>FS', '']
+    positions = aa_change_string_split[0].split('_')  # ['324', '325']
 
     # check positions are consecutive
     if int(positions[1]) == (int(positions[0]) + 1):
@@ -624,9 +643,9 @@ def split_dual_consecutive_aa_change(aa_change_string):
     Splits into two aa_changes, e.g. ['L324F', 'A325S']
     """
     # searches for the 'LA>FS' type pattern - putting the regex in parentheses means that the matched pattern will also be returned in the list
-    aa_change_string_split = re.split('([A-Z][A-Z]>[A-Z][A-Z])', aa_change_string) # ['324_325', 'LA>FS', '']
-    positions = aa_change_string_split[0].split('_') # ['324', '325']
-    resnames = aa_change_string_split[1].split('>') # ['LA', 'FS']
+    aa_change_string_split = re.split('([A-Z][A-Z]>[A-Z][A-Z])', aa_change_string)  # ['324_325', 'LA>FS', '']
+    positions = aa_change_string_split[0].split('_')  # ['324', '325']
+    resnames = aa_change_string_split[1].split('>')  # ['LA', 'FS']
     aa_changes = [resnames[0][0] + positions[0] + resnames[1][0], resnames[0][1] + positions[1] + resnames[1][1]]
     return aa_changes
 
@@ -642,8 +661,9 @@ def percent_cases_with_mutations(gene_node):
     num_in_cohort = 0
     for cancer_study in cancer_studies:
         try:
-            nmutants += len( gene_node.findall('mutants/mutant[@study="%(cancer_study)s"]' % vars()) )
-            num_in_cohort += int( gene_node.find('mutants/mutant[@study="%(cancer_study)s"]' % vars()).get('num_in_cohort') )
+            nmutants += len(gene_node.findall('mutants/mutant[@study="%(cancer_study)s"]' % vars()))
+            num_in_cohort += int(
+                gene_node.find('mutants/mutant[@study="%(cancer_study)s"]' % vars()).get('num_in_cohort'))
         except TypeError:
             continue
 
@@ -689,7 +709,7 @@ class AddCbioportalMAFData(object):
             case_id = maf_row.Tumor_Sample_Barcode
             if case_id not in case_rows:
                 case_rows[case_id] = models.CbioportalCase(
-                     crawl_number=self.current_crawl_number, case_id=case_id, study=study
+                    crawl_number=self.current_crawl_number, case_id=case_id, study=study
                 )
                 db.session.add(case_rows[case_id])
 

--- a/targetexplorer/cbioportal.py
+++ b/targetexplorer/cbioportal.py
@@ -1,4 +1,5 @@
 import urllib2
+import time
 import re
 import os
 import datetime
@@ -362,7 +363,7 @@ def retrieve_mutants_xml(output_xml_filepath, cancer_studies, gene_ids,
         if lines[0][0:25] == '# Warning:  Unknown gene:':
             print lines[0]
             #raise Exception
-            continue 
+            continue
         print 'Done retrieving ExtendedMutation data from cBioPortal.'
 
         # These dicts will be used later to assign percent_in_cohort values for a given mutation by matching case_id and aa_change
@@ -551,25 +552,30 @@ def retrieve_extended_mutation_datatxt(case_set_id,
         'private': use private cBioPortal data
     write_to_filepath: str (or False)
     """
-    gene_ids_string = '+'.join(gene_ids)
-    mutation_url = 'http://www.cbioportal.org/{0}/' \
-                   'webservice.do' \
-                   '?cmd=getMutationData' \
-                   '&case_set_id={1}' \
-                   '&genetic_profile_id={2}' \
-                   '&gene_list={3}'.format(
-                       portal_version,
-                       case_set_id,
-                       genetic_profile_id,
-                       gene_ids_string
-                   )
-    response = urllib2.urlopen(mutation_url)
-    page = response.read(1000000000)
-    if write_to_filepath:
-        with open(write_to_filepath, 'w') as ofile:
-            ofile.write(page)
-    lines = page.splitlines()
-    return lines
+    lines_list = list()
+    #gene_ids_string = '+'.join(gene_ids)
+    for gene_id in gene_ids:
+        gene_ids_string = gene_id
+        mutation_url = 'http://www.cbioportal.org/{0}/' \
+                       'webservice.do' \
+                       '?cmd=getMutationData' \
+                       '&case_set_id={1}' \
+                       '&genetic_profile_id={2}' \
+                       '&gene_list={3}'.format(
+                           portal_version,
+                           case_set_id,
+                           genetic_profile_id,
+                           gene_ids_string
+                       )
+        response = urllib2.urlopen(mutation_url)
+        page = response.read(1000000000)
+        if write_to_filepath:
+            with open(write_to_filepath, 'w') as ofile:
+                ofile.write(page)
+        lines = page.splitlines()
+        lines_list.extend(lines)
+        time.sleep(0.5)
+    return lines_list
 
 
 def match_dual_consecutive_aa_change(aa_change_string):

--- a/targetexplorer/cbioportal.py
+++ b/targetexplorer/cbioportal.py
@@ -361,7 +361,8 @@ def retrieve_mutants_xml(output_xml_filepath, cancer_studies, gene_ids,
             continue
         if lines[0][0:25] == '# Warning:  Unknown gene:':
             print lines[0]
-            raise Exception
+            #raise Exception
+            continue 
         print 'Done retrieving ExtendedMutation data from cBioPortal.'
 
         # These dicts will be used later to assign percent_in_cohort values for a given mutation by matching case_id and aa_change

--- a/targetexplorer/oncotator.py
+++ b/targetexplorer/oncotator.py
@@ -56,6 +56,6 @@ def retrieve_oncotator_mutation_data_as_json(
 def retrieve_oncotator_mutation_data(search_string_query, maxreadlength=100000000):
     base_url = 'http://www.broadinstitute.org/oncotator/mutation/{0}/'
     url_request_string = base_url.format(search_string_query)
-    response = urllib2.urlopen(url_request_string)
+    response = urllib2.urlopen(url_request_string, timeout=None)
     page = response.read(maxreadlength)
     return page

--- a/targetexplorer/uniprot.py
+++ b/targetexplorer/uniprot.py
@@ -474,7 +474,7 @@ class GatherUniProt(object):
         # = PDB entries (from UniProt XML) =
         # keep X-ray and NMR structures (not "Model")
         pdbs = uniprot_entry_node.xpath(
-            './dbReference[@type="PDB"]/property[@type="method"][@value="X-ray" or @value="NMR"]/property[@type="chain"][@value!="None"]/..'
+            './dbReference[@type="PDB"]/property[@type="method"][@value="X-ray" or @value="NMR"]/..'
         )
         pdb_data = []
         for p in pdbs:

--- a/targetexplorer/uniprot.py
+++ b/targetexplorer/uniprot.py
@@ -474,7 +474,7 @@ class GatherUniProt(object):
         # = PDB entries (from UniProt XML) =
         # keep X-ray and NMR structures (not "Model")
         pdbs = uniprot_entry_node.xpath(
-            './dbReference[@type="PDB"]/property[@type="method"][@value="X-ray" or @value="NMR"]/..'
+            './dbReference[@type="PDB"]/property[@type="method"][@value="X-ray" or @value="NMR"]/property[@type="chain"][@value!="None"]/..'
         )
         pdb_data = []
         for p in pdbs:

--- a/targetexplorer/uniprot.py
+++ b/targetexplorer/uniprot.py
@@ -476,6 +476,7 @@ class GatherUniProt(object):
         pdbs = uniprot_entry_node.xpath(
             './dbReference[@type="PDB"]/property[@type="method"][@value="X-ray" or @value="NMR"]/..'
         )
+
         pdb_data = []
         for p in pdbs:
             pdb_id = p.get('id')


### PR DESCRIPTION
When gathering data from Uniprot, was getting an error that I believe was related to entries that had NMR or XRAY structures that did not have chains specified. This is the error: 

```
Traceback (most recent call last):
  File "/Users/albaness/miniconda3/envs/py27/bin/DoraGatherUniProt.py", line 4, in <module>
    __import__('pkg_resources').run_script('targetexplorer==0.2', 'DoraGatherUniProt.py')
  File "/Users/albaness/miniconda3/envs/py27/lib/python2.7/site-packages/setuptools-23.0.0-py2.7.egg/pkg_resources/__init__.py", line 719, in run_script
  File "/Users/albaness/miniconda3/envs/py27/lib/python2.7/site-packages/setuptools-23.0.0-py2.7.egg/pkg_resources/__init__.py", line 1504, in run_script
  File "/Users/albaness/miniconda3/envs/py27/lib/python2.7/site-packages/targetexplorer-0.2-py2.7.egg/EGG-INFO/scripts/DoraGatherUniProt.py", line 41, in <module>
    commit_to_db=not args.nocommit
  File "/Users/albaness/miniconda3/envs/py27/lib/python2.7/site-packages/targetexplorer-0.2-py2.7.egg/targetexplorer/uniprot.py", line 59, in __init__
    self.extract_detailed_uniprot_data(uniprot_entry)
  File "/Users/albaness/miniconda3/envs/py27/lib/python2.7/site-packages/targetexplorer-0.2-py2.7.egg/targetexplorer/uniprot.py", line 494, in extract_detailed_uniprot_data
    chains_span_str = p.find('property[@type="chains"]').get('value')
AttributeError: 'NoneType' object has no attribute 'get'
```

The change I've made should only pick up structures that have chains listed